### PR TITLE
fix: check for root

### DIFF
--- a/blocks/example-file-block/index.tsx
+++ b/blocks/example-file-block/index.tsx
@@ -74,10 +74,15 @@ type Props = {
   metadata: any;
 } & (FileData | FolderData);
 
-const root = ReactDOM.createRoot(document.getElementById("root")!);
-
 function setProps(props: Props, blocksAPI: BlocksAPI) {
-  root.render(<BlockComponent {...props} {...blocksAPI} />);
+  let root: ReactDOM.Root | undefined;
+  let component = <BlockComponent {...props} {...blocksAPI} />;
+  if (root) {
+    root.render(component);
+  } else {
+    root = ReactDOM.createRoot(document.getElementById("root")!);
+    root.render(component);
+  }
 }
 
 export default setProps;


### PR DESCRIPTION
Addresses the Todo item about HMR not working.

I'm not sure I fully understand which of these implementation details we want to hide from end users – is this too in the weeds for the actual block template itself?